### PR TITLE
Fixed https connection with proxy.

### DIFF
--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpsServiceConnectionSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpsServiceConnectionSE.java
@@ -64,9 +64,8 @@ public class HttpsServiceConnectionSE implements ServiceConnection {
         } else {
             connection =
                     (HttpsURLConnection) new URL(HttpsTransportSE.PROTOCOL, host, port, file).openConnection(proxy);
-
         }
-        connection = (HttpsURLConnection) new URL(HttpsTransportSE.PROTOCOL, host, port, file).openConnection();
+
         updateConnectionParameters(timeout);
     }
 


### PR DESCRIPTION
Connection created with proxy was overwritten by a new connection without proxy.