### PR TITLE
Store all http headers from the response in HttpResponseException

### DIFF
--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpResponseException.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpResponseException.java
@@ -1,6 +1,7 @@
 package org.ksoap2.transport;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * HttpResponseException is an IOException that is to be thrown when a Http response code is different from 200.
@@ -11,6 +12,7 @@ import java.io.IOException;
 public class HttpResponseException extends IOException {
 
     private int statusCode;
+    private List responseHeaders;
 
     public HttpResponseException(int statusCode) {
         super();
@@ -20,6 +22,12 @@ public class HttpResponseException extends IOException {
     public HttpResponseException(String detailMessage, int statusCode) {
         super(detailMessage);
         this.statusCode = statusCode;
+    }
+
+    public HttpResponseException(String detailMessage, int statusCode,List responseHeaders) {
+        super(detailMessage);
+        this.statusCode = statusCode;
+        this.responseHeaders=responseHeaders;
     }
 
     public HttpResponseException(String message, Throwable cause, int statusCode) {
@@ -39,5 +47,14 @@ public class HttpResponseException extends IOException {
      */
     public int getStatusCode() {
         return statusCode;
+    }
+
+    /**
+     * Returns all http headers from this response
+     *
+     * @return response code
+     */
+    public List getResponseHeaders() {
+        return responseHeaders;
     }
 }

--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
@@ -232,7 +232,7 @@ public class HttpTransportSE extends Transport {
             //first check the response code....
             if (status != 200) {
                 //throw new IOException("HTTP request failed, HTTP status: " + status);
-                throw new HttpResponseException("HTTP request failed, HTTP status: " + status, status);
+                throw new HttpResponseException("HTTP request failed, HTTP status: " + status, status,retHeaders);
             }
 
             if (contentLength > 0) {


### PR DESCRIPTION
When we get error reponse from the server (code !=200) the code throws HttpResponseException exception with the status code only. But in some cases we need to have access to all http headers (needed for example for 401 Unauthorized reponse in case when we want to implement negotiation mechanism like in Kerberos authentication).
This pull requests adds response headers to this exception