### PR TITLE
Namespace extensions

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/AttributeContainer.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/AttributeContainer.java
@@ -51,6 +51,20 @@ public class AttributeContainer implements HasAttributes{
     }
 
     /**
+     * Get the attribute with the given name
+     *
+     * @throws RuntimeException if the attribute does not exist
+     */
+    public Object getAttribute(String namespace,String name) {
+        Integer i = attributeIndex(namespace,name);
+        if (i != null) {
+            return getAttribute(i.intValue());
+        } else {
+            throw new RuntimeException("illegal property: " + name);
+        }
+    }
+
+    /**
      * Get the toString value of the attribute with the given name.
      *
      * @throws RuntimeException if the attribute does not exist
@@ -65,6 +79,19 @@ public class AttributeContainer implements HasAttributes{
     }
 
     /**
+     * Get the toString value of the attribute with the given name.
+     *
+     * @throws RuntimeException if the attribute does not exist
+     */
+    public String getAttributeAsString(String namespace,String name) {
+        Integer i = attributeIndex(namespace,name);
+        if (i != null) {
+            return getAttribute(i.intValue()).toString();
+        } else {
+            throw new RuntimeException("illegal property: " + name);
+        }
+    }
+    /**
      * Knows whether the given attribute exists
      */
     public boolean hasAttribute(final String name) {
@@ -76,6 +103,16 @@ public class AttributeContainer implements HasAttributes{
     }
 
     /**
+     * Knows whether the given attribute exists
+     */
+    public boolean hasAttribute(final String namespace,final String name) {
+        if (attributeIndex(namespace,name) != null) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+    /**
      * Get an attribute without chance of throwing an exception
      *
      * @param name the name of the attribute to retrieve
@@ -83,6 +120,21 @@ public class AttributeContainer implements HasAttributes{
      */
     public Object getAttributeSafely(String name) {
         Integer i = attributeIndex(name);
+        if (i != null) {
+            return getAttribute(i.intValue());
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get an attribute without chance of throwing an exception
+     *
+     * @param name the name of the attribute to retrieve
+     * @return the value of the attribute if it exists; {@code null} if it does not exist
+     */
+    public Object getAttributeSafely(String namespace,String name) {
+        Integer i = attributeIndex(namespace,name);
         if (i != null) {
             return getAttribute(i.intValue());
         } else {
@@ -107,9 +159,36 @@ public class AttributeContainer implements HasAttributes{
         }
     }
 
+    /**
+     * Get an attributes' toString value without chance of throwing an
+     * exception.
+
+     * @param name
+     * @return the value of the attribute,s toString method if it exists; ""
+     * if it does not exist
+     */
+    public Object getAttributeSafelyAsString(String namespace,String name) {
+        Integer i = attributeIndex(namespace,name);
+        if (i != null) {
+            return getAttribute(i.intValue()).toString();
+        } else {
+            return "";
+        }
+    }
+
     private Integer attributeIndex(String name) {
         for (int i = 0; i < attributes.size(); i++) {
             if (name.equals(((AttributeInfo) attributes.elementAt(i)).getName())) {
+                return new Integer(i);
+            }
+        }
+        return null;
+    }
+
+    private Integer attributeIndex(String namespace,String name) {
+        for (int i = 0; i < attributes.size(); i++) {
+            AttributeInfo attrInfo=(AttributeInfo) attributes.elementAt(i);
+            if (name.equals(attrInfo.getName()) && namespace.equals(attrInfo.getNamespace())) {
                 return new Integer(i);
             }
         }
@@ -159,13 +238,25 @@ public class AttributeContainer implements HasAttributes{
      * @return {@code this} object.
      */
     public void addAttribute(String name, Object value) {
+        addAttribute(null,name,value);
+    }
+
+    /**
+     * Adds a attribute (parameter) to the object.
+     *
+     * @param namespace  The namespace of the attribute
+     * @param name  The name of the attribute
+     * @param value the value of the attribute
+     * @return {@code this} object.
+     */
+    public void addAttribute(String namespace,String name, Object value) {
         AttributeInfo attributeInfo = new AttributeInfo();
         attributeInfo.name = name;
+        attributeInfo.namespace = namespace;
         attributeInfo.type = value == null ? PropertyInfo.OBJECT_CLASS : value.getClass();
         attributeInfo.value = value;
         addAttribute(attributeInfo);
     }
-
     /**
      * Add an attribute if the value is not null.
      * @param name
@@ -174,6 +265,18 @@ public class AttributeContainer implements HasAttributes{
     public void addAttributeIfValue(String name, Object value) {
         if (value != null) {
             addAttribute(name, value);
+        }
+    }
+
+    /**
+     * Add an attribute if the value is not null.
+     * @param namespace  The namespace of the attribute
+     * @param name
+     * @param value
+     */
+    public void addAttributeIfValue(String namespace,String name, Object value) {
+        if (value != null) {
+            addAttribute(namespace,name, value);
         }
     }
 

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapObject.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapObject.java
@@ -54,6 +54,8 @@ public class SoapObject extends AttributeContainer implements KvmSerializable {
      */
     protected Vector properties = new Vector();
 
+    protected String innerText;
+
     // TODO: accessing properties and attributes would work much better if we
     // kept a list of known properties instead of iterating through the list
     // each time
@@ -175,6 +177,228 @@ public class SoapObject extends AttributeContainer implements KvmSerializable {
         Integer index = propertyIndex(name);
         if (index != null) {
             return getProperty(index.intValue());
+        } else {
+            throw new RuntimeException("illegal property: " + name);
+        }
+    }
+
+    /**
+     * Get the property with the given name
+     *
+     * return null
+     *             if the property does not exist
+     */
+    public Object getProperty(String namespace,String name) {
+        Integer index = propertyIndex(namespace,name);
+        if (index != null) {
+            return getProperty(index.intValue());
+        }
+        return null;
+    }
+
+    /**
+     * Get a property using namespace and name without chance of throwing an exception
+     *
+     * @return the property if it exists; if not, {@link NullSoapObject} is
+     *         returned
+     */
+    public Object getPropertySafely(final String namespace,final String name) {
+        Integer i = propertyIndex(namespace,name);
+        if (i != null) {
+            return getProperty(i.intValue());
+        } else {
+            return new NullSoapObject();
+        }
+    }
+
+    /**
+     * Get the toString value of a property without chance of throwing an
+     * exception
+     *
+     * @return the string value of the property if it exists; if not, #EMPTY_STRING is
+     *         returned
+     */
+    public String getPropertySafelyAsString(final String namespace,final String name) {
+        Integer i = propertyIndex(namespace,name);
+        if (i != null) {
+            Object foo = getProperty(i.intValue());
+            if (foo == null) {
+                return EMPTY_STRING;
+            } else {
+                return foo.toString();
+            }
+        } else {
+            return EMPTY_STRING;
+        }
+    }
+
+    /**
+     * Get a property without chance of throwing an exception. An object can be
+     * provided to this method; if the property is not found, this object will
+     * be returned.
+     *
+     * @param defaultThing
+     *            the object to return if the property is not found
+     * @return the property if it exists; defaultThing if the property does not
+     *         exist
+     */
+    public Object getPropertySafely(final String namespace,final String name, final Object defaultThing) {
+        Integer i = propertyIndex(namespace,name);
+        if (i != null) {
+            return getProperty(i.intValue());
+        } else {
+            return defaultThing;
+        }
+    }
+
+    /**
+     * Get the toString value of a property without chance of throwing an
+     * exception. An object can be provided to this method; if the property is
+     * not found, this object's string representation will be returned.
+     *
+     * @param defaultThing
+     *            toString of the object to return if the property is not found
+     * @return the property toString if it exists; defaultThing toString if the
+     *         property does not exist, if the defaultThing is null #EMPTY_STRING
+     *         is returned
+     */
+    public String getPropertySafelyAsString(final String namespace,final String name,
+                                            final Object defaultThing) {
+        Integer i = propertyIndex(namespace,name);
+        if (i != null) {
+            Object property = getProperty(i.intValue());
+            if (property != null) {
+                return property.toString();
+            } else {
+                return EMPTY_STRING;
+            }
+        } else {
+            if (defaultThing != null) {
+                return defaultThing.toString();
+            } else {
+                return EMPTY_STRING;
+            }
+        }
+    }
+
+    /**
+     * Get the primitive property with the given name.
+     *
+     * @param name
+     * @return PropertyInfo containing an empty string if property either complex or empty
+     */
+    public Object getPrimitiveProperty(final String namespace,final String name){
+        Integer index = propertyIndex(namespace,name);
+        if (index != null){
+            PropertyInfo propertyInfo = (PropertyInfo) properties.elementAt(index.intValue());
+            if (propertyInfo.getType()!=SoapObject.class && propertyInfo.getValue()!=null){
+                return propertyInfo.getValue();
+            } else {
+                propertyInfo = new PropertyInfo();
+                propertyInfo.setType(String.class);
+                propertyInfo.setValue(EMPTY_STRING);
+                propertyInfo.setName(name);
+                propertyInfo.setNamespace(namespace);
+                return (Object) propertyInfo.getValue();
+            }
+        } else {
+            throw new RuntimeException("illegal property: " + name);
+        }
+    }
+
+    /**
+     * Get the toString value of the primitive property with the given name.
+     * Returns empty string if property either complex or empty
+     *
+     * @param name
+     * @return the string value of the property
+     */
+    public String getPrimitivePropertyAsString(final String namespace,final String name){
+        Integer index = propertyIndex(namespace,name);
+        if (index != null){
+            PropertyInfo propertyInfo = (PropertyInfo) properties.elementAt(index.intValue());
+            if (propertyInfo.getType()!=SoapObject.class && propertyInfo.getValue()!=null){
+                return propertyInfo.getValue().toString();
+            } else {
+                return EMPTY_STRING;
+            }
+        } else {
+            throw new RuntimeException("illegal property: " + name);
+        }
+    }
+
+    /**
+     * Get the toString value of a primitive property without chance of throwing an
+     * exception
+     *
+     * @param name
+     * @return the string value of the property if it exists and is primitive; if not, #EMPTY_STRING is
+     *         returned
+     */
+    public Object getPrimitivePropertySafely(final String namespace,final String name) {
+        Integer index = propertyIndex(namespace,name);
+        if (index != null){
+            PropertyInfo propertyInfo = (PropertyInfo) properties.elementAt(index.intValue());
+            if (propertyInfo.getType()!=SoapObject.class && propertyInfo.getValue()!=null){
+                return propertyInfo.getValue().toString();
+            } else {
+                propertyInfo = new PropertyInfo();
+                propertyInfo.setType(String.class);
+                propertyInfo.setValue(EMPTY_STRING);
+                propertyInfo.setName(name);
+                propertyInfo.setNamespace(namespace);
+                return (Object) propertyInfo.getValue();
+            }
+        } else {
+            return new NullSoapObject();
+        }
+    }
+
+    /**
+     * Get the toString value of a primitive property without chance of throwing an
+     * exception
+     *
+     * @param name
+     * @return the string value of the property if it exists and is primitive; if not, #EMPTY_STRING is
+     *         returned
+     */
+    public String getPrimitivePropertySafelyAsString(final String namespace,final String name) {
+        Integer index = propertyIndex(namespace,name);
+        if (index != null){
+            PropertyInfo propertyInfo = (PropertyInfo) properties.elementAt(index.intValue());
+            if (propertyInfo.getType()!=SoapObject.class && propertyInfo.getValue()!=null){
+                return propertyInfo.getValue().toString();
+            } else {
+                return EMPTY_STRING;
+            }
+        } else {
+            return EMPTY_STRING;
+        }
+    }
+
+    /**
+     * Knows whether the given property exists
+     */
+    public boolean hasProperty(final String namespace,final String name) {
+        if (propertyIndex(namespace,name) != null) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Get the toString value of the property.
+     *
+     * @param namespace
+     * @param name
+     * @return
+     */
+
+    public String getPropertyAsString(String namespace,String name) {
+        Integer index = propertyIndex(namespace,name);
+        if (index != null) {
+            return getProperty(index.intValue()).toString();
         } else {
             throw new RuntimeException("illegal property: " + name);
         }
@@ -399,6 +623,17 @@ public class SoapObject extends AttributeContainer implements KvmSerializable {
     }
 
 
+    private Integer propertyIndex(String namespace,String name) {
+        if (name != null && namespace!=null) {
+            for (int i = 0; i < properties.size(); i++) {
+                PropertyInfo info= (PropertyInfo) properties.elementAt(i);
+                if (name.equals(info.getName()) && namespace.equals(info.getNamespace())) {
+                    return new Integer(i);
+                }
+            }
+        }
+        return null;
+    }
     /**
      * Returns the number of properties
      *
@@ -519,6 +754,46 @@ public class SoapObject extends AttributeContainer implements KvmSerializable {
     }
 
     /**
+     * Adds a property (parameter) to the object. This is essentially a sub
+     * element.
+     *
+     * @param namespace
+     *            The namespace of the property
+     * @param name
+     *            The name of the property
+     * @param value
+     *            the value of the property
+     */
+    public SoapObject addProperty(String namespace,String name, Object value) {
+        PropertyInfo propertyInfo = new PropertyInfo();
+        propertyInfo.name = name;
+        propertyInfo.namespace = namespace;
+        propertyInfo.type = value == null ? PropertyInfo.OBJECT_CLASS : value
+                .getClass();
+        propertyInfo.value = value;
+        return addProperty(propertyInfo);
+    }
+
+    /**
+     * Add a property only if the value is not null.
+     *
+     * @param namespace
+     *            The namespace of the property
+     * @param name
+     *            The name of the property
+     * @param value
+     *            the value of the property
+     * @return
+     */
+    public SoapObject addPropertyIfValue(String namespace,String name, Object value) {
+        if (value != null) {
+            return addProperty(namespace,name, value);
+        } else {
+            return this;
+        }
+    }
+
+    /**
      * Add a property only if the value is not null.
      *
      * @param name
@@ -611,8 +886,12 @@ public class SoapObject extends AttributeContainer implements KvmSerializable {
         return buf.toString();
     }
     public String getInnerText() {
-         return null;
+         return innerText;
     }
-    public void setInnerText(String s) {
+
+    public void setInnerText(String innerText)
+    {
+        this.innerText=innerText;
     }
+
 }

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapObject.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapObject.java
@@ -193,7 +193,9 @@ public class SoapObject extends AttributeContainer implements KvmSerializable {
         if (index != null) {
             return getProperty(index.intValue());
         }
-        return null;
+        else {
+            throw new RuntimeException("illegal property: " + name);
+        }
     }
 
     /**
@@ -202,7 +204,7 @@ public class SoapObject extends AttributeContainer implements KvmSerializable {
      * @return the property if it exists; if not, {@link NullSoapObject} is
      *         returned
      */
-    public Object getPropertySafely(final String namespace,final String name) {
+    public Object getPropertyByNamespaceSafely(final String namespace, final String name) {
         Integer i = propertyIndex(namespace,name);
         if (i != null) {
             return getProperty(i.intValue());
@@ -218,7 +220,7 @@ public class SoapObject extends AttributeContainer implements KvmSerializable {
      * @return the string value of the property if it exists; if not, #EMPTY_STRING is
      *         returned
      */
-    public String getPropertySafelyAsString(final String namespace,final String name) {
+    public String getPropertyByNamespaceSafelyAsString(final String namespace,final String name) {
         Integer i = propertyIndex(namespace,name);
         if (i != null) {
             Object foo = getProperty(i.intValue());

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
@@ -298,8 +298,8 @@ public class SoapSerializationEnvelope extends SoapEnvelope {
             }
 
             while (parser.getEventType() != XmlPullParser.END_TAG) {
-                so.addProperty(parser.getNamespace(),parser.getName(), read(parser, so, so.getPropertyCount(), null, null,
-                        PropertyInfo.OBJECT_TYPE));
+                so.addProperty(parser.getNamespace(),parser.getName(), read(parser, so, so.getPropertyCount(),
+                        null, null, PropertyInfo.OBJECT_TYPE));
                 parser.nextTag();
             }
             result = so;

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
@@ -298,7 +298,7 @@ public class SoapSerializationEnvelope extends SoapEnvelope {
             }
 
             while (parser.getEventType() != XmlPullParser.END_TAG) {
-                so.addProperty(parser.getName(), read(parser, so, so.getPropertyCount(), null, null,
+                so.addProperty(parser.getNamespace(),parser.getName(), read(parser, so, so.getPropertyCount(), null, null,
                         PropertyInfo.OBJECT_TYPE));
                 parser.nextTag();
             }

--- a/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
@@ -179,6 +179,12 @@ abstract public class Transport {
         this.url = url;
     }
 
+    public String getUrl()
+    {
+        return url;
+    }
+
+
     /**
      * Sets the version tag for the outgoing soap call. Example <?xml
      * version=\"1.0\" encoding=\"UTF-8\"?>

--- a/ksoap2-base/src/test/java/org/ksoap2/serialization/SoapObjectTest.java
+++ b/ksoap2-base/src/test/java/org/ksoap2/serialization/SoapObjectTest.java
@@ -159,9 +159,27 @@ public class SoapObjectTest extends TestCase {
         assertFalse(soapObject.hasProperty("Prop1"));
     }
 
+    public void testHasProperty_namespace() {
+        soapObject.addProperty("test_namespace","Prop8", "Eight");
+        assertTrue(soapObject.hasProperty("test_namespace","Prop8"));
+        assertTrue(soapObject.hasProperty("Prop8"));
+        assertFalse(soapObject.hasProperty("wrong_namespace","Prop8"));
+    }
+
     public void testGetProperty_ThrowsWhenIllegalPropertyName() {
         try {
             soapObject.getProperty("blah");
+            fail();
+        } catch (RuntimeException e) {
+            assertEquals(RuntimeException.class.getName(), e.getClass()
+                    .getName());
+            assertEquals("illegal property: blah", e.getMessage());
+        }
+    }
+
+    public void testGetProperty_namespace_ThrowsWhenIllegalPropertyName() {
+        try {
+            Object obj=soapObject.getProperty("namespace", "blah");
             fail();
         } catch (RuntimeException e) {
             assertEquals(RuntimeException.class.getName(), e.getClass()
@@ -178,8 +196,24 @@ public class SoapObjectTest extends TestCase {
         assertEquals("Eight", soapObject.getPropertySafely("Prop8"));
     }
 
+    public void testGetPropertySafely_namespace_GivesPropertyWhenItExists() {
+        soapObject.addProperty("namespace","Prop1", "One");
+        soapObject.addProperty("namespace","Prop8", "Eight");
+
+        assertEquals("One", soapObject.getPropertyByNamespaceSafely("namespace","Prop1"));
+        assertEquals("Eight", soapObject.getPropertyByNamespaceSafely("namespace", "Prop8"));
+        assertEquals("One", soapObject.getPropertySafely("Prop1"));
+        assertEquals("Eight", soapObject.getPropertySafely("Prop8"));
+    }
+
     public void testGetPropertySafely_GivesANullObjectWhenThePropertyDoesNotExist() {
         Object nullObject = soapObject.getPropertySafely("Prop1");
+        assertNotNull(nullObject);
+        assertNull(nullObject.toString());
+    }
+
+    public void testGetPropertySafely_namespace_GivesANullObjectWhenThePropertyDoesNotExist() {
+        Object nullObject = soapObject.getPropertyByNamespaceSafely("namespace", "Prop1");
         assertNotNull(nullObject);
         assertNull(nullObject.toString());
     }
@@ -210,6 +244,25 @@ public class SoapObjectTest extends TestCase {
 
         soapObject.addPropertyIfValue(propertyInfo, "GotOne");
         assertTrue(soapObject.hasProperty(name));
+    }
+
+    public void testAddPropertyIfValue_namespace() {
+        String name = "NotHere";
+        String value = null;
+        soapObject.addPropertyIfValue("namespace",name, value);
+        assertFalse(soapObject.hasProperty(name));
+        assertFalse(soapObject.hasProperty("namespace",name));
+
+        PropertyInfo propertyInfo = new PropertyInfo();
+        propertyInfo.name = name;
+        propertyInfo.value = value;
+        propertyInfo.namespace = "namespace";
+
+        soapObject.addPropertyIfValue(propertyInfo);
+
+        assertFalse(soapObject.hasProperty(name));
+        assertFalse(soapObject.hasProperty("namespace",name));
+
     }
 
     public void testAddAttributeIfValue() {
@@ -257,6 +310,30 @@ public class SoapObjectTest extends TestCase {
         assertTrue("".equals(soapObject.getPropertySafelyAsString(null, null)));
 
         assertTrue("test".equals(soapObject.getPropertySafelyAsString(null, "test")));
+    }
+
+    public void getPropertyByNamespaceSafelyAsString() {
+        String name = "StringProperty";
+        String value = "a string";
+        String namespace = "namespace";
+        soapObject.addProperty(namespace,name, value);
+
+        assertEquals(value, soapObject.getPropertyByNamespaceSafelyAsString(namespace,name));
+
+        String name2 = "NotThere";
+        assertEquals("", soapObject.getPropertyByNamespaceSafelyAsString(namespace,name2));
+        assertEquals(value, soapObject.getPropertyByNamespaceSafelyAsString(namespace,name));
+
+        String anInteger = "AnInteger";
+        String integerValue = "12";
+
+        soapObject.addProperty(anInteger, new Integer(12));
+        assertEquals(integerValue, soapObject.getPropertyByNamespaceSafelyAsString(namespace,anInteger));
+
+        mojSoapObejObject.addProperty(namespace,"jaaa", null);
+        assertEquals("",
+                mojSoapObejObject.getPropertyByNamespaceSafelyAsString(namespace,"jaaa"));
+
     }
 
     public void testGetAttributeAsString() {


### PR DESCRIPTION
There is a bug in reading service response. In some places namespace information is skipped. My fix read namespace for these elements and put it into SoapObject so we can know the namespace of the elements (if we want)
Additionally I've added methods to works with elements by {namespace}:{name} fullname. In the current version you can only invoke getProperty method with the name. So in case if your soap message has two elements with the same name but from different namespace, you couldn't take a correct property.